### PR TITLE
Report a process failure on regressions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -734,6 +734,8 @@ fn report_success(s: Summary, p: PathBuf) {
     println!("");
     println!("full report: {}", p.to_str().unwrap());
     println!("");
+    
+    if s.regressed > 0 { std::process::exit(-2) }
 }
 
 #[derive(Default)]


### PR DESCRIPTION
I apologize if this is completely misunderstanding the purpose of exit codes, but it seems to me that experiencing a regression should not be considered a "successful" execution. This enables a regression that is detected by `cargo crusader` to trigger a travis failure. 

It may be desirable to expose a flag to override this behaviour -- or maybe opt into it. This seems like the right default, though.
